### PR TITLE
Fix spelling

### DIFF
--- a/projects.rst
+++ b/projects.rst
@@ -69,7 +69,7 @@ Commercial Projects
 Computer Games
 --------------
 
--   `Batman Arkahm Origins
+-   `Batman Arkham Origins
     <http://en.wikipedia.org/wiki/Batman:_Arkham_Origins>`_ — parts of online
     services code and backend. *2012-2013*
 -   `RAD Soldiers <http://www.warchest.com/games/radsoldiers>`_ — game


### PR DESCRIPTION
In the list of projects "Arkham" in "Batman Arkham Origins" was spelled incorrectly. Link to wikipedia article was correct.